### PR TITLE
Don't render skeleton rows in their own Table component

### DIFF
--- a/src/components/display/SkeletonTableBody.tsx
+++ b/src/components/display/SkeletonTableBody.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Tbody, Table } from "@chakra-ui/react"
+import { Tbody } from "@chakra-ui/react"
 
 import { SkeletonTableRow } from "./SkeletonTableRow"
 
@@ -21,8 +21,6 @@ export const SkeletonTableBody = (props: SkeletonTableBodyProps) => {
 
   // Return the rows while also applying a fade-out gradient overlay
   return (
-    <Table>
-      <Tbody>{skeletonTableRows}</Tbody>
-    </Table>
+    <Tbody>{skeletonTableRows}</Tbody>
   )
 }

--- a/src/components/display/SkeletonTableBody.tsx
+++ b/src/components/display/SkeletonTableBody.tsx
@@ -20,7 +20,5 @@ export const SkeletonTableBody = (props: SkeletonTableBodyProps) => {
   }, [rowCount, columnCount])
 
   // Return the rows while also applying a fade-out gradient overlay
-  return (
-    <Tbody>{skeletonTableRows}</Tbody>
-  )
+  return <Tbody>{skeletonTableRows}</Tbody>
 }

--- a/src/components/display/SkeletonTableRow.tsx
+++ b/src/components/display/SkeletonTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Stack, Skeleton, Tr, Td, Table } from "@chakra-ui/react"
+import { Stack, Skeleton, Tr, Td } from "@chakra-ui/react"
 
 export interface SkeletonTableRowProps {
   columnCount?: number
@@ -20,14 +20,12 @@ export const SkeletonTableRow = (props: SkeletonTableRowProps) => {
   }, [columnCount, columnWidth])
 
   return (
-    <Table>
-      <Tr>
-        <Td colSpan={100}>
-          <Stack direction="row" w="100%">
-            {columns}
-          </Stack>
-        </Td>
-      </Tr>
-    </Table>
+    <Tr>
+      <Td colSpan={100}>
+        <Stack direction="row" w="100%">
+          {columns}
+        </Stack>
+      </Td>
+    </Tr>
   )
 }

--- a/stories/components/display/SkeletonTableBody.stories.tsx
+++ b/stories/components/display/SkeletonTableBody.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Table } from "@chakra-ui/react"
 import { Meta, Story } from "@storybook/react"
 
 import {
@@ -18,7 +19,9 @@ const meta: Meta = {
 export default meta
 
 const Template: Story<SkeletonTableBodyProps> = (args) => (
-  <SkeletonTableBody {...args} />
+  <Table>
+    <SkeletonTableBody {...args} />
+  </Table>
 )
 
 export const Default = Template.bind({})

--- a/stories/components/display/SkeletonTableRow.stories.tsx
+++ b/stories/components/display/SkeletonTableRow.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Table, Tbody } from "@chakra-ui/react"
 import { Meta, Story } from "@storybook/react"
 
 import {
@@ -18,7 +19,11 @@ const meta: Meta = {
 export default meta
 
 const Template: Story<SkeletonTableRowProps> = (args) => (
-  <SkeletonTableRow {...args} />
+  <Table>
+    <Tbody>
+      <SkeletonTableRow {...args} />
+    </Tbody>
+  </Table>
 )
 
 export const Default = Template.bind({})


### PR DESCRIPTION
I missed this during earlier review, sorry about that. We don't expect `SkeletonTableBody` to render its own `Table` component, rather it should only render a `Tbody`.

I had considered renaming this to `SkeletonTable` instead, however as far as React performance goes, when we switch between `isLoading` state and not, it's cheaper to unmount a few loading rows than to unmount a whole loading table and mount the "real" table.

This way, we mount the loading rows inside the "real" table and switch the fake rows out with the real rows once loading state toggles, rather than a whole table.