### PR TITLE
fix: correct typo referencing UMD build entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "license": "MIT",
   "type": "module",
   "types": "dist/index.d.ts",
-  "main": "dist/react-ui.umd.js",
+  "main": "dist/react-ui.umd.cjs",
   "module": "dist/react-ui.js",
   "homepage": "https://github.com/perxhealth/react-ui",
   "exports": {
     ".": {
       "import": "./dist/react-ui.js",
-      "require": "./dist/react-ui.umd.js"
+      "require": "./dist/react-ui.umd.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
This hasn't affected us yet, but an issue to fix nonetheless!