### PR TITLE
PX-907 / Extend input max length + externalise libphonenumber

### DIFF
--- a/src/components/forms/PhoneInput.tsx
+++ b/src/components/forms/PhoneInput.tsx
@@ -133,6 +133,15 @@ export const PhoneInput = (props: PhoneInputProps) => {
     [setNumber, currentCountry, onChange]
   )
 
+  const maxLength = React.useMemo(() => {
+    const { maxNumberLength, countryCode } = currentCountry
+    if (isInternational) {
+      return maxNumberLength
+    } else {
+      return maxNumberLength + (countryCode === CountryCode.AU ? 2 : 1)
+    }
+  }, [currentCountry, isInternational])
+
   return (
     <InputGroup>
       {isInternational && (
@@ -144,7 +153,7 @@ export const PhoneInput = (props: PhoneInputProps) => {
       <Input
         {...inputProps}
         placeholder={inputPlaceholder}
-        maxLength={currentCountry.maxNumberLength}
+        maxLength={maxLength}
         onChange={onInputChange}
         value={number}
       />

--- a/src/components/forms/PhoneInput.tsx
+++ b/src/components/forms/PhoneInput.tsx
@@ -30,7 +30,8 @@ export interface CountryData {
   emoji: string
   countryCode: string
   callingCode: `+${string}`
-  maxNumberLength: number
+  intlMaxNumberLength: number
+  localMaxNumberLength: number
   exampleNumber: string
 }
 
@@ -44,7 +45,8 @@ const countries: Countries = {
     emoji: "🇦🇺",
     countryCode: "AU",
     callingCode: "+61",
-    maxNumberLength: 9,
+    intlMaxNumberLength: 9,
+    localMaxNumberLength: 11,
     exampleNumber: "491 570 006",
   },
   [CountryCode.US]: {
@@ -52,7 +54,8 @@ const countries: Countries = {
     emoji: "🇺🇸",
     countryCode: "US",
     callingCode: "+1",
-    maxNumberLength: 10,
+    intlMaxNumberLength: 10,
+    localMaxNumberLength: 11,
     exampleNumber: "555 123 4567",
   },
 }
@@ -134,11 +137,10 @@ export const PhoneInput = (props: PhoneInputProps) => {
   )
 
   const maxLength = React.useMemo(() => {
-    const { maxNumberLength, countryCode } = currentCountry
     if (isInternational) {
-      return maxNumberLength
+      return currentCountry.intlMaxNumberLength
     } else {
-      return maxNumberLength + (countryCode === CountryCode.AU ? 2 : 1)
+      return currentCountry.localMaxNumberLength
     }
   }, [currentCountry, isInternational])
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         "framer-motion",
         "lucide-react",
         "prop-types",
+        "libphonenumber-js",
       ],
       output: {
         globals: {
@@ -32,6 +33,7 @@ export default defineConfig({
           "framer-motion": "FramerMotion",
           "lucide-react": "LucideReact",
           "prop-types": "PropTypes",
+          "libphonenumber-js": "libphonenumber",
         },
       },
     },


### PR DESCRIPTION
## What is the desired outcome?
Allow phone number length to include the area code + externalise `libphonenumber-js`

## Why do we want this?
We want the user to be able to enter various formats of their phone number.

## How?
Include libphonenumber in rollup options + conditionally modify input max length.

## Testing?
Testing to be carried out by Pedro once PPP has been updated.

## Screenshots (optional)
nil

## Anything else? Questions? Concerns?
nil
