### PR TITLE
Update node + pnpm tool-verions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-pnpm 7.28.0
-nodejs 16.14.0
+nodejs 20.6.1
+pnpm 8.9.0


### PR DESCRIPTION
## What is the desired outcome?
Use up-to-date node + pnpm version

## Why do we want this?
Node 16 is not out of date and poses a security risk.

## How?
Update `.tool-versions` to use the latest versions

## Testing?
Build should be green

## Screenshots (optional)
N/A

## Anything else? Questions? Concerns?
N/A
